### PR TITLE
APF `n_points` fix & Temporary fitting slices

### DIFF
--- a/antecedent_fitting.py
+++ b/antecedent_fitting.py
@@ -146,8 +146,8 @@ def _create_cluster_fit_forecast(_antecedent_params,
 
         # clustering, fitting, testing
         fvm.cluster()
-        fvm.fit()
-        fvm.forecast()
+        fvm.fit(n_points=fvm.train_data.shape[0])
+        fvm.forecast(n_points=fvm.train_data.shape[0])
 
         # calculating errors
         mse = mean_squared_error(fvm.h[:-1], fvm.train_data.values ** 2, squared=True)

--- a/model.py
+++ b/model.py
@@ -365,7 +365,8 @@ class FuzzyVolatilityModel:
             self.train_data = train_data.copy()
 
         _fitting_slice_ini = self._fitting_slice
-        self._fitting_slice = slice(-n_points if n_points is not None else None, None)
+        if n_points is not None:
+            self._fitting_slice = slice(-n_points, None)
 
         self._fit()
 
@@ -469,7 +470,8 @@ class FuzzyVolatilityModel:
 
     def forecast(self, n_points: int = None):
         _fitting_slice_ini = self._fitting_slice
-        self._fitting_slice = slice(-n_points if n_points is not None else None, None)
+        if n_points is not None:
+            self._fitting_slice = slice(-n_points, None)
 
         self._forecast()
 
@@ -518,7 +520,8 @@ class FuzzyVolatilityModel:
             # then do forecast before running the main algorithm
 
             _fitting_slice_ini = self._fitting_slice
-            self._fitting_slice = slice(-n_points if n_points is not None else None, None)
+            if n_points is not None:
+                self._fitting_slice = slice(-n_points if n_points is not None else None, None)
 
             self.forecast(n_points=n_points)
 


### PR DESCRIPTION
# 2 fixes are made:
* `n_points` kwarg in the `FVM.fit()` & `FVM.forecast()` functions should be set as `fvm.train_data.shape[0]` (in antecedent_fitting.py). This is because the whole train dataset should be used when fitting and forecasting for the first time
* If `n_points` kwarg in functions `FVM.fit()`, `FVM.forecast()`, `FVM.feed_daily_data()` is set to None (default), `FVM._fitting_slice` should not be changed